### PR TITLE
Fix custom sequence increment from 50 to 1

### DIFF
--- a/backend/src/main/java/com/madeg/logistics/entity/Category.java
+++ b/backend/src/main/java/com/madeg/logistics/entity/Category.java
@@ -25,23 +25,14 @@ import org.hibernate.annotations.Parameter;
 public class Category {
 
   @Id
-  @GeneratedValue(
-    strategy = GenerationType.SEQUENCE,
-    generator = "category_code_seq"
-  )
-  @GenericGenerator(
-    name = "category_code_seq",
-    strategy = "com.madeg.logistics.entity.CustomSequenceGenerator",
-    parameters = { @Parameter(name = "prefix", value = "category_code_") }
-  )
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "category_code_seq")
+  @GenericGenerator(name = "category_code_seq", strategy = "com.madeg.logistics.entity.CustomSequenceGenerator", parameters = {
+      @Parameter(name = "prefix", value = "category_code_"), @Parameter(name = "increment_size", value = "1") })
   @Column(name = "category_code", unique = true, nullable = false)
   private String categoryCode;
 
   @ManyToOne
-  @JoinColumn(
-    name = "parent_category_code",
-    referencedColumnName = "category_code"
-  )
+  @JoinColumn(name = "parent_category_code", referencedColumnName = "category_code")
   private Category parentCategory;
 
   @Column(name = "name", nullable = false)
@@ -63,10 +54,8 @@ public class Category {
   }
 
   public boolean isStateChanged(Category other) {
-    return (
-      !Objects.equals(name, other.name) ||
-      !Objects.equals(description, other.description) ||
-      !Objects.equals(parentCategory, other.parentCategory)
-    );
+    return (!Objects.equals(name, other.name) ||
+        !Objects.equals(description, other.description) ||
+        !Objects.equals(parentCategory, other.parentCategory));
   }
 }

--- a/backend/src/main/java/com/madeg/logistics/entity/CustomSequenceGenerator.java
+++ b/backend/src/main/java/com/madeg/logistics/entity/CustomSequenceGenerator.java
@@ -11,37 +11,36 @@ import org.hibernate.HibernateException;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.id.enhanced.SequenceStyleGenerator;
+import org.hibernate.service.ServiceRegistry;
 import org.hibernate.type.Type;
 
 @Slf4j
 public class CustomSequenceGenerator extends SequenceStyleGenerator {
 
   private String prefix = "_";
+  private int incrementSize = 1;
 
   @Override
   public Serializable generate(
-    SharedSessionContractImplementor session,
-    Object object
-  ) throws HibernateException {
+      SharedSessionContractImplementor session,
+      Object object) throws HibernateException {
     String sequenceName = prefix + "seq";
 
     Connection connection = null;
     try {
       ConnectionProvider connectionProvider = session
-        .getFactory()
-        .getServiceRegistry()
-        .getService(ConnectionProvider.class);
+          .getFactory()
+          .getServiceRegistry()
+          .getService(ConnectionProvider.class);
       connection = connectionProvider.getConnection();
 
       PreparedStatement preparedStatement = connection.prepareStatement(
-        "SELECT nextval('" + sequenceName + "')"
-      );
+          "SELECT nextval('" + sequenceName + "')");
       ResultSet resultSet = preparedStatement.executeQuery();
 
       if (resultSet.next()) {
         int nextValue = resultSet.getInt(1);
-        String generatedId =
-          (prefix.contains("_") ? prefix.split("_")[0] : "") + "_" + nextValue;
+        String generatedId = (prefix.contains("_") ? prefix.split("_")[0] : "") + "_" + nextValue;
         return generatedId;
       }
     } catch (SQLException e) {
@@ -60,14 +59,19 @@ public class CustomSequenceGenerator extends SequenceStyleGenerator {
 
   @Override
   public void configure(
-    Type type,
-    Properties params,
-    org.hibernate.service.ServiceRegistry serviceRegistry
-  ) {
+      Type type,
+      Properties params,
+      ServiceRegistry serviceRegistry) {
     super.configure(type, params, serviceRegistry);
     String parameterPrefix = params.getProperty("prefix");
     if (parameterPrefix != null) {
       prefix = parameterPrefix;
     }
+
+    String incrementSizeParam = params.getProperty("increment_size");
+    if (incrementSizeParam != null) {
+      incrementSize = Integer.parseInt(incrementSizeParam);
+    }
+
   }
 }

--- a/backend/src/main/java/com/madeg/logistics/entity/Product.java
+++ b/backend/src/main/java/com/madeg/logistics/entity/Product.java
@@ -29,24 +29,15 @@ import org.hibernate.annotations.Parameter;
 public class Product {
 
   @Id
-  @GeneratedValue(
-    strategy = GenerationType.SEQUENCE,
-    generator = "product_code_seq"
-  )
-  @GenericGenerator(
-    name = "product_code_seq",
-    strategy = "com.madeg.logistics.entity.CustomSequenceGenerator",
-    parameters = { @Parameter(name = "prefix", value = "product_code_") }
-  )
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "product_code_seq")
+  @GenericGenerator(name = "product_code_seq", strategy = "com.madeg.logistics.entity.CustomSequenceGenerator", parameters = {
+      @Parameter(name = "prefix", value = "product_code_"),
+      @Parameter(name = "increment_size", value = "1") })
   @Column(name = "product_code", unique = true, nullable = false)
   private String productCode;
 
   @ManyToOne
-  @JoinColumn(
-    name = "category_code",
-    referencedColumnName = "category_code",
-    nullable = false
-  )
+  @JoinColumn(name = "category_code", referencedColumnName = "category_code", nullable = false)
   private Category category;
 
   @Column(name = "type", nullable = false)
@@ -103,23 +94,19 @@ public class Product {
   }
 
   public boolean isStateChanged(ProductPatch patchInput, byte[] newImgBytes) {
-    return (
-      !Objects.equals(name, patchInput.getName()) ||
-      (
-        price != null &&
-        patchInput.getPrice() != null &&
-        price.compareTo(patchInput.getPrice()) != 0
-      ) ||
-      stock != patchInput.getStock() ||
-      (
-        category == null
-          ? patchInput.getCategoryCode() != null
-          : !category.getCategoryCode().equals(patchInput.getCategoryCode())
-      ) ||
-      !Objects.equals(description, patchInput.getDescription()) ||
-      !Objects.equals(type, patchInput.getType()) ||
-      !Arrays.equals(img, newImgBytes) ||
-      !Objects.equals(barcode, patchInput.getBarcode())
-    );
+    return (!Objects.equals(name, patchInput.getName()) ||
+        (price != null &&
+            patchInput.getPrice() != null &&
+            price.compareTo(patchInput.getPrice()) != 0)
+        ||
+        stock != patchInput.getStock() ||
+        (category == null
+            ? patchInput.getCategoryCode() != null
+            : !category.getCategoryCode().equals(patchInput.getCategoryCode()))
+        ||
+        !Objects.equals(description, patchInput.getDescription()) ||
+        !Objects.equals(type, patchInput.getType()) ||
+        !Arrays.equals(img, newImgBytes) ||
+        !Objects.equals(barcode, patchInput.getBarcode()));
   }
 }

--- a/backend/src/main/java/com/madeg/logistics/entity/Store.java
+++ b/backend/src/main/java/com/madeg/logistics/entity/Store.java
@@ -25,15 +25,9 @@ import org.hibernate.annotations.Parameter;
 public class Store {
 
   @Id
-  @GeneratedValue(
-    strategy = GenerationType.SEQUENCE,
-    generator = "store_code_seq"
-  )
-  @GenericGenerator(
-    name = "store_code_seq",
-    strategy = "com.madeg.logistics.entity.CustomSequenceGenerator",
-    parameters = { @Parameter(name = "prefix", value = "store_code_") }
-  )
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "store_code_seq")
+  @GenericGenerator(name = "store_code_seq", strategy = "com.madeg.logistics.entity.CustomSequenceGenerator", parameters = {
+      @Parameter(name = "prefix", value = "store_code_"), @Parameter(name = "increment_size", value = "1") })
   @Column(name = "store_code", unique = true, nullable = false)
   private String storeCode;
 
@@ -80,12 +74,10 @@ public class Store {
   }
 
   public boolean isStateChanged(StorePatch patchInput) {
-    return (
-      !Objects.equals(name, patchInput.getName()) ||
-      !Objects.equals(address, patchInput.getAddress()) ||
-      !Objects.equals(fixedCost, patchInput.getFixedCost()) ||
-      !Objects.equals(commissionRate, patchInput.getCommissionRate()) ||
-      !Objects.equals(description, patchInput.getDescription())
-    );
+    return (!Objects.equals(name, patchInput.getName()) ||
+        !Objects.equals(address, patchInput.getAddress()) ||
+        !Objects.equals(fixedCost, patchInput.getFixedCost()) ||
+        !Objects.equals(commissionRate, patchInput.getCommissionRate()) ||
+        !Objects.equals(description, patchInput.getDescription()));
   }
 }


### PR DESCRIPTION
Hi, @JoshRyu 

Do you remember the [issue](https://github.com/JoshRyu/logistics/issues/26)?

The sequences created by the custom sequence generators default to an increment of 50.
While this isn't a significant issue, it's not ideal and is somewhat inconvenient, so I've adjusted their increments to 1.


![image](https://github.com/JoshRyu/logistics/assets/142554606/76f4ea29-9828-41b8-82e0-a72565277c2b)


And this is the part or the Hibernate Log:
```
Hibernate: create sequence category_code_seq start with 1 increment by 1
Hibernate: create sequence product_code_seq start with 1 increment by 1
Hibernate: create sequence sales_history_id_seq start with 1 increment by 1
Hibernate: create sequence statistics_id_seq start with 1 increment by 1
Hibernate: create sequence store_code_seq start with 1 increment by 1
Hibernate: create sequence store_product_id_seq start with 1 increment by 1
Hibernate: create sequence user_seq start with 1 increment by 1
```

Take a look at this pull request !