### PR TITLE
Add product search api

### DIFF
--- a/backend/src/main/java/com/madeg/logistics/controller/ProductController.java
+++ b/backend/src/main/java/com/madeg/logistics/controller/ProductController.java
@@ -2,6 +2,7 @@ package com.madeg.logistics.controller;
 
 import com.madeg.logistics.domain.CommonRes;
 import com.madeg.logistics.domain.ProductInput;
+import com.madeg.logistics.domain.ProductListReq;
 import com.madeg.logistics.domain.ProductPatch;
 import com.madeg.logistics.domain.ProductRes;
 import com.madeg.logistics.entity.Product;
@@ -64,7 +65,9 @@ public class ProductController {
   @GetMapping
   public ResponseEntity<ProductRes> getProductList(
       @RequestParam(required = false) ProductType type,
+      @ModelAttribute @Valid ProductListReq productListReq,
       @PageableDefault(size = 10, page = 0, sort = "productCode", direction = Sort.Direction.ASC) Pageable pageable) {
+
     return ResponseEntity
         .status(ResponseCode.RETRIEVED.getStatus())
         .body(productService.getProducts(type, pageable));

--- a/backend/src/main/java/com/madeg/logistics/controller/ProductController.java
+++ b/backend/src/main/java/com/madeg/logistics/controller/ProductController.java
@@ -69,14 +69,23 @@ public class ProductController {
       @RequestParam(required = false) ProductSearchType searchType,
       @RequestParam(required = false) String searchKeyWord,
       @PageableDefault(size = 10, page = 0, sort = "productCode", direction = Sort.Direction.ASC) Pageable pageable) {
+    ProductRes products;
+    try {
 
-    ProductListReq productListReq = new ProductListReq();
-    productListReq.setSearchKeyWord(searchKeyWord);
-    productListReq.setSearchType(searchType);
+      ProductListReq productListReq = new ProductListReq();
+      productListReq.setSearchKeyWord(searchKeyWord);
+      productListReq.setSearchType(searchType);
+
+      products = productService.getProducts(type, productListReq, pageable);
+    } catch (Exception e) {
+      return ResponseEntity.status(ResponseCode.INTERNALERROR.getStatus()).body(
+          new ProductRes(ResponseCode.INTERNALERROR.getCode(), e.getMessage(), null, null));
+    }
 
     return ResponseEntity
         .status(ResponseCode.RETRIEVED.getStatus())
-        .body(productService.getProducts(type, productListReq, pageable));
+        .body(products);
+
   }
 
   @Operation(summary = "Get a Specific Product by Code")

--- a/backend/src/main/java/com/madeg/logistics/controller/ProductController.java
+++ b/backend/src/main/java/com/madeg/logistics/controller/ProductController.java
@@ -78,8 +78,8 @@ public class ProductController {
 
       products = productService.getProducts(type, productListReq, pageable);
     } catch (Exception e) {
-      return ResponseEntity.status(ResponseCode.INTERNALERROR.getStatus()).body(
-          new ProductRes(ResponseCode.INTERNALERROR.getCode(), e.getMessage(), null, null));
+      return ResponseEntity.status(ResponseCode.INTERNAL_ERROR.getStatus()).body(
+          new ProductRes(ResponseCode.INTERNAL_ERROR.getCode(), e.getMessage(), null, null));
     }
 
     return ResponseEntity

--- a/backend/src/main/java/com/madeg/logistics/controller/ProductController.java
+++ b/backend/src/main/java/com/madeg/logistics/controller/ProductController.java
@@ -6,6 +6,7 @@ import com.madeg.logistics.domain.ProductListReq;
 import com.madeg.logistics.domain.ProductPatch;
 import com.madeg.logistics.domain.ProductRes;
 import com.madeg.logistics.entity.Product;
+import com.madeg.logistics.enums.ProductSearchType;
 import com.madeg.logistics.enums.ProductType;
 import com.madeg.logistics.enums.ResponseCode;
 import com.madeg.logistics.service.ProductService;
@@ -65,12 +66,17 @@ public class ProductController {
   @GetMapping
   public ResponseEntity<ProductRes> getProductList(
       @RequestParam(required = false) ProductType type,
-      @ModelAttribute @Valid ProductListReq productListReq,
+      @RequestParam(required = false) ProductSearchType searchType,
+      @RequestParam(required = false) String searchKeyWord,
       @PageableDefault(size = 10, page = 0, sort = "productCode", direction = Sort.Direction.ASC) Pageable pageable) {
+
+    ProductListReq productListReq = new ProductListReq();
+    productListReq.setSearchKeyWord(searchKeyWord);
+    productListReq.setSearchType(searchType);
 
     return ResponseEntity
         .status(ResponseCode.RETRIEVED.getStatus())
-        .body(productService.getProducts(type, pageable));
+        .body(productService.getProducts(type, productListReq, pageable));
   }
 
   @Operation(summary = "Get a Specific Product by Code")

--- a/backend/src/main/java/com/madeg/logistics/controller/SalesHistoryController.java
+++ b/backend/src/main/java/com/madeg/logistics/controller/SalesHistoryController.java
@@ -68,13 +68,21 @@ public class SalesHistoryController {
       @PathVariable(name = "store_code", required = true) String storeCode,
       @PathVariable(name = "product_code", required = true) String productCode,
       @PageableDefault(size = 10, page = 0) Pageable pageable) {
+
+    SalesHistoryRes salesHistory;
+    try {
+      salesHistory = salesHistoryService.getSalesHistoryByStoreAndProduct(
+          storeCode,
+          productCode,
+          pageable);
+
+    } catch (Exception e) {
+      return ResponseEntity.status(ResponseCode.INTERNAL_ERROR.getStatus()).body(
+          new SalesHistoryRes(ResponseCode.INTERNAL_ERROR.getCode(), e.getMessage(), null, null));
+    }
     return ResponseEntity
         .status(ResponseCode.RETRIEVED.getStatus())
-        .body(
-            salesHistoryService.getSalesHistoryByStoreAndProduct(
-                storeCode,
-                productCode,
-                pageable));
+        .body(salesHistory);
   }
 
   @Operation(summary = "Get the list of all Sales History in the Store in specific month")
@@ -85,14 +93,22 @@ public class SalesHistoryController {
       @RequestParam @NotNull @Min(1900) Integer salesYear,
       @RequestParam @NotNull @Min(1) @Max(12) Integer salesMonth,
       @PageableDefault(size = 10, page = 0) Pageable pageable) {
+
+    SalesHistoryRes salesHistory;
+    try {
+      salesHistory = salesHistoryService.getSalesHistoryByStoreAndSalesMonth(
+          storeCode,
+          salesYear,
+          salesMonth,
+          pageable);
+
+    } catch (Exception e) {
+      return ResponseEntity.status(ResponseCode.INTERNAL_ERROR.getStatus()).body(
+          new SalesHistoryRes(ResponseCode.INTERNAL_ERROR.getCode(), e.getMessage(), null, null));
+    }
     return ResponseEntity
         .status(ResponseCode.RETRIEVED.getStatus())
-        .body(
-            salesHistoryService.getSalesHistoryByStoreAndSalesMonth(
-                storeCode,
-                salesYear,
-                salesMonth,
-                pageable));
+        .body(salesHistory);
   }
 
   @Operation(summary = "Update Sales History Of Store Product")

--- a/backend/src/main/java/com/madeg/logistics/controller/StoreProductController.java
+++ b/backend/src/main/java/com/madeg/logistics/controller/StoreProductController.java
@@ -64,9 +64,18 @@ public class StoreProductController {
   public ResponseEntity<StoreProductRes> getProductsInStore(
       @PathVariable(name = "store_code", required = true) String storeCode,
       @PageableDefault(size = 10, page = 0) Pageable pageable) {
+
+    StoreProductRes storeProducts;
+    try {
+      storeProducts = storeProductService.getStoreProducts(storeCode, pageable);
+
+    } catch (Exception e) {
+      return ResponseEntity.status(ResponseCode.INTERNAL_ERROR.getStatus()).body(
+          new StoreProductRes(ResponseCode.INTERNAL_ERROR.getCode(), e.getMessage(), null, null));
+    }
     return ResponseEntity
         .status(ResponseCode.RETRIEVED.getStatus())
-        .body(storeProductService.getStoreProducts(storeCode, pageable));
+        .body(storeProducts);
   }
 
   @Operation(summary = "Update a Specific Store Product By Store and Product Code")

--- a/backend/src/main/java/com/madeg/logistics/controller/StoreStatisticsController.java
+++ b/backend/src/main/java/com/madeg/logistics/controller/StoreStatisticsController.java
@@ -58,8 +58,15 @@ public class StoreStatisticsController {
   public ResponseEntity<StoreStatisticsRes> getStoreStatisticsByStore(
       @PathVariable(name = "store_code", required = true) String storeCode,
       @PageableDefault(size = 10, page = 0) Pageable pageable) {
+    StoreStatisticsRes storeStatistics;
+    try {
+      storeStatistics = storeStatisticsService.getStoreStatistics(storeCode, pageable);
+    } catch (Exception e) {
+      return ResponseEntity.status(ResponseCode.INTERNAL_ERROR.getStatus()).body(
+          new StoreStatisticsRes(ResponseCode.INTERNAL_ERROR.getCode(), e.getMessage(), null, null));
+    }
     return ResponseEntity
         .status(ResponseCode.RETRIEVED.getStatus())
-        .body(storeStatisticsService.getStoreStatistics(storeCode, pageable));
+        .body(storeStatistics);
   }
 }

--- a/backend/src/main/java/com/madeg/logistics/controller/UserController.java
+++ b/backend/src/main/java/com/madeg/logistics/controller/UserController.java
@@ -57,8 +57,8 @@ public class UserController {
           userService.refreshAccessToken(refreshToken),
           ResponseCode.SUCCESS.getStatus());
     } catch (IllegalArgumentException e) {
-      return ResponseEntity.status(ResponseCode.BADREQUEST.getStatus())
-          .body(ResponseCode.BADREQUEST.getMessage("유효하지 않은 Refresh Token 입니다"));
+      return ResponseEntity.status(ResponseCode.BAD_REQUEST.getStatus())
+          .body(ResponseCode.BAD_REQUEST.getMessage("유효하지 않은 Refresh Token 입니다"));
     }
   }
 

--- a/backend/src/main/java/com/madeg/logistics/domain/ProductListReq.java
+++ b/backend/src/main/java/com/madeg/logistics/domain/ProductListReq.java
@@ -2,7 +2,6 @@ package com.madeg.logistics.domain;
 
 import com.madeg.logistics.enums.ProductSearchType;
 
-import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -12,7 +11,6 @@ import lombok.Setter;
 @NoArgsConstructor
 public class ProductListReq {
 
-    @NotBlank(message = "한 글자 이상 검색하셔야 합니다")
     private String searchKeyWord;
 
     private ProductSearchType searchType;

--- a/backend/src/main/java/com/madeg/logistics/domain/ProductListReq.java
+++ b/backend/src/main/java/com/madeg/logistics/domain/ProductListReq.java
@@ -1,0 +1,20 @@
+package com.madeg.logistics.domain;
+
+import com.madeg.logistics.enums.ProductSearchType;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ProductListReq {
+
+    @NotBlank(message = "한 글자 이상 검색하셔야 합니다")
+    private String searchKeyWord;
+
+    private ProductSearchType searchType;
+
+}

--- a/backend/src/main/java/com/madeg/logistics/domain/ProductSpecification.java
+++ b/backend/src/main/java/com/madeg/logistics/domain/ProductSpecification.java
@@ -1,0 +1,52 @@
+package com.madeg.logistics.domain;
+
+import org.springframework.data.jpa.domain.Specification;
+
+import com.madeg.logistics.entity.Product;
+import com.madeg.logistics.enums.ProductType;
+
+import jakarta.persistence.criteria.Predicate;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ProductSpecification {
+
+    public static Specification<Product> withDynamicQuery(ProductType type, ProductListReq productListReq) {
+        return (root, query, builder) -> {
+            List<Predicate> predicates = new ArrayList<>();
+
+            if (type != null) {
+                predicates.add(builder.equal(root.get("type"), type));
+            }
+
+            if (productListReq != null && productListReq.getSearchKeyWord() != null
+                    && !productListReq.getSearchKeyWord().isEmpty()) {
+                switch (productListReq.getSearchType()) {
+                    case PRODUCT_NAME:
+                        predicates.add(builder.like(root.get("name"), "%" + productListReq.getSearchKeyWord() + "%"));
+                        break;
+                    case CATEGORY_NAME:
+                        predicates.add(builder.like(root.get("category").get("name"),
+                                "%" + productListReq.getSearchKeyWord() + "%"));
+                        break;
+                    case STOCK:
+                        predicates.add(
+                                builder.equal(root.get("stock"), Integer.parseInt(productListReq.getSearchKeyWord())));
+                        break;
+                    case PRICE:
+                        predicates.add(
+                                builder.equal(root.get("price"), new BigDecimal(productListReq.getSearchKeyWord())));
+                        break;
+                    case DESCRIPTION:
+                        predicates.add(
+                                builder.like(root.get("description"), "%" + productListReq.getSearchKeyWord() + "%"));
+                        break;
+                }
+            }
+
+            return builder.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}

--- a/backend/src/main/java/com/madeg/logistics/enums/ProductSearchType.java
+++ b/backend/src/main/java/com/madeg/logistics/enums/ProductSearchType.java
@@ -1,0 +1,10 @@
+package com.madeg.logistics.enums;
+
+public enum ProductSearchType {
+
+    PRODUCT_NAME,
+    CATEGORY_NAME,
+    STOCK,
+    PRICE,
+    DESCRIPTION
+}

--- a/backend/src/main/java/com/madeg/logistics/enums/ResponseCode.java
+++ b/backend/src/main/java/com/madeg/logistics/enums/ResponseCode.java
@@ -18,7 +18,8 @@ public enum ResponseCode {
     UNCHANGED(HttpStatus.NO_CONTENT, "{0}은(는) 변경 사항이 없어 업데이트되지 않았습니다."),
     CONFLICT(HttpStatus.CONFLICT, "{0}이(가) 이미 존재합니다."),
     BADREQUEST(HttpStatus.BAD_REQUEST, "{0}."),
-    NOTFOUND(HttpStatus.NOT_FOUND, "{0}을(를) 찾을 수 없습니다.");
+    NOTFOUND(HttpStatus.NOT_FOUND, "{0}을(를) 찾을 수 없습니다."),
+    INTERNALERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Error");
 
     private final HttpStatus status;
     private final String message;

--- a/backend/src/main/java/com/madeg/logistics/enums/ResponseCode.java
+++ b/backend/src/main/java/com/madeg/logistics/enums/ResponseCode.java
@@ -17,9 +17,9 @@ public enum ResponseCode {
 
     UNCHANGED(HttpStatus.NO_CONTENT, "{0}은(는) 변경 사항이 없어 업데이트되지 않았습니다."),
     CONFLICT(HttpStatus.CONFLICT, "{0}이(가) 이미 존재합니다."),
-    BADREQUEST(HttpStatus.BAD_REQUEST, "{0}."),
-    NOTFOUND(HttpStatus.NOT_FOUND, "{0}을(를) 찾을 수 없습니다."),
-    INTERNALERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Error");
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "{0}."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "{0}을(를) 찾을 수 없습니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Error");
 
     private final HttpStatus status;
     private final String message;

--- a/backend/src/main/java/com/madeg/logistics/exception/ControllerExceptionHandler.java
+++ b/backend/src/main/java/com/madeg/logistics/exception/ControllerExceptionHandler.java
@@ -18,8 +18,8 @@ public class ControllerExceptionHandler {
       HttpMessageNotReadableException ex) {
     String errorMessage = ex.getLocalizedMessage();
     return ResponseEntity
-        .status(ResponseCode.BADREQUEST.getStatus())
-        .body(new CommonRes(ResponseCode.BADREQUEST.getCode(), errorMessage));
+        .status(ResponseCode.BAD_REQUEST.getStatus())
+        .body(new CommonRes(ResponseCode.BAD_REQUEST.getCode(), errorMessage));
   }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -31,7 +31,7 @@ public class ControllerExceptionHandler {
         : "잘못된 요청입니다";
 
     return ResponseEntity
-        .status(ResponseCode.BADREQUEST.getStatus())
-        .body(new CommonRes(ResponseCode.BADREQUEST.getCode(), errorMessage));
+        .status(ResponseCode.BAD_REQUEST.getStatus())
+        .body(new CommonRes(ResponseCode.BAD_REQUEST.getCode(), errorMessage));
   }
 }

--- a/backend/src/main/java/com/madeg/logistics/repository/CategoryRepository.java
+++ b/backend/src/main/java/com/madeg/logistics/repository/CategoryRepository.java
@@ -2,11 +2,12 @@ package com.madeg.logistics.repository;
 
 import com.madeg.logistics.entity.Category;
 import java.util.List;
-import org.springframework.data.repository.CrudRepository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CategoryRepository extends CrudRepository<Category, String> {
+public interface CategoryRepository extends JpaRepository<Category, String> {
   Category findByName(String name);
 
   Category findByCategoryCode(String categoryCode);

--- a/backend/src/main/java/com/madeg/logistics/repository/ProductRepository.java
+++ b/backend/src/main/java/com/madeg/logistics/repository/ProductRepository.java
@@ -2,15 +2,18 @@ package com.madeg.logistics.repository;
 
 import com.madeg.logistics.entity.Product;
 import com.madeg.logistics.enums.ProductType;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ProductRepository extends CrudRepository<Product, String> {
-  Page<Product> findAll(Pageable pageable);
+public interface ProductRepository extends JpaRepository<Product, String>, JpaSpecificationExecutor<Product> {
+  Page<Product> findAll(Specification<Product> spec, Pageable pageable);
 
   Page<Product> findByType(ProductType type, Pageable pageable);
 

--- a/backend/src/main/java/com/madeg/logistics/repository/SalesHistoryRepository.java
+++ b/backend/src/main/java/com/madeg/logistics/repository/SalesHistoryRepository.java
@@ -4,26 +4,26 @@ import com.madeg.logistics.entity.SalesHistory;
 import com.madeg.logistics.entity.StoreProduct;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SalesHistoryRepository
-    extends JpaRepository<SalesHistory, Long> {
-  SalesHistory findByStoreProductAndSalesMonth(
-      StoreProduct storeProduct,
-      String salesMonth);
+        extends JpaRepository<SalesHistory, Long> {
+    SalesHistory findByStoreProductAndSalesMonth(
+            StoreProduct storeProduct,
+            String salesMonth);
 
-  SalesHistory findByStoreProduct_StoreProductIdAndSalesMonth(
-      Long storeProductId,
-      String salesMonth);
+    SalesHistory findByStoreProduct_StoreProductIdAndSalesMonth(
+            Long storeProductId,
+            String salesMonth);
 
-  Page<SalesHistory> findByStoreProductOrderBySalesMonth(
-      StoreProduct storeProduct,
-      Pageable pageable);
+    Page<SalesHistory> findByStoreProductOrderBySalesMonth(
+            StoreProduct storeProduct,
+            Pageable pageable);
 
-  Page<SalesHistory> findByStoreProductAndSalesMonth(
-      StoreProduct storeProduct,
-      String salesMonth,
-      Pageable pageable);
+    Page<SalesHistory> findByStoreProductAndSalesMonth(
+            StoreProduct storeProduct,
+            String salesMonth,
+            Pageable pageable);
 }

--- a/backend/src/main/java/com/madeg/logistics/repository/SalesHistoryRepository.java
+++ b/backend/src/main/java/com/madeg/logistics/repository/SalesHistoryRepository.java
@@ -4,30 +4,26 @@ import com.madeg.logistics.entity.SalesHistory;
 import com.madeg.logistics.entity.StoreProduct;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SalesHistoryRepository
-  extends CrudRepository<SalesHistory, Long> {
+    extends JpaRepository<SalesHistory, Long> {
   SalesHistory findByStoreProductAndSalesMonth(
-    StoreProduct storeProduct,
-    String salesMonth
-  );
+      StoreProduct storeProduct,
+      String salesMonth);
 
   SalesHistory findByStoreProduct_StoreProductIdAndSalesMonth(
-    Long storeProductId,
-    String salesMonth
-  );
+      Long storeProductId,
+      String salesMonth);
 
   Page<SalesHistory> findByStoreProductOrderBySalesMonth(
-    StoreProduct storeProduct,
-    Pageable pageable
-  );
+      StoreProduct storeProduct,
+      Pageable pageable);
 
   Page<SalesHistory> findByStoreProductAndSalesMonth(
-    StoreProduct storeProduct,
-    String salesMonth,
-    Pageable pageable
-  );
+      StoreProduct storeProduct,
+      String salesMonth,
+      Pageable pageable);
 }

--- a/backend/src/main/java/com/madeg/logistics/repository/StoreProductRepository.java
+++ b/backend/src/main/java/com/madeg/logistics/repository/StoreProductRepository.java
@@ -6,24 +6,20 @@ import com.madeg.logistics.entity.StoreProduct;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface StoreProductRepository
-  extends CrudRepository<StoreProduct, Long> {
+    extends JpaRepository<StoreProduct, Long> {
   StoreProduct findByStore(Store store);
 
   StoreProduct findByStoreAndProduct(Store store, Product product);
 
-  @Query(
-    "SELECT sp.storeProductId FROM StoreProduct sp WHERE sp.store.storeCode = :storeCode"
-  )
+  @Query("SELECT sp.storeProductId FROM StoreProduct sp WHERE sp.store.storeCode = :storeCode")
   List<Long> findStoreProductIdsByStore(String storeCode);
 
-  @Query(
-    "SELECT sp FROM StoreProduct sp WHERE sp.store.storeCode = :storeCode ORDER BY sp.product.productCode ASC"
-  )
+  @Query("SELECT sp FROM StoreProduct sp WHERE sp.store.storeCode = :storeCode ORDER BY sp.product.productCode ASC")
   Page<StoreProduct> findByStoreCode(String storeCode, Pageable pageable);
 }

--- a/backend/src/main/java/com/madeg/logistics/repository/StoreRepository.java
+++ b/backend/src/main/java/com/madeg/logistics/repository/StoreRepository.java
@@ -2,11 +2,12 @@ package com.madeg.logistics.repository;
 
 import com.madeg.logistics.entity.Store;
 import java.util.List;
-import org.springframework.data.repository.CrudRepository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface StoreRepository extends CrudRepository<Store, String> {
+public interface StoreRepository extends JpaRepository<Store, String> {
   Store findByName(String name);
 
   Store findByStoreCode(String storeCode);

--- a/backend/src/main/java/com/madeg/logistics/repository/StoreStatisticsRepository.java
+++ b/backend/src/main/java/com/madeg/logistics/repository/StoreStatisticsRepository.java
@@ -4,12 +4,12 @@ import com.madeg.logistics.entity.Store;
 import com.madeg.logistics.entity.StoreStatistics;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface StoreStatisticsRepository
-  extends CrudRepository<StoreStatistics, Long> {
+    extends JpaRepository<StoreStatistics, Long> {
   StoreStatistics findByStoreAndMonth(Store store, String month);
 
   Page<StoreStatistics> findByStoreOrderByMonth(Store store, Pageable pageable);

--- a/backend/src/main/java/com/madeg/logistics/repository/UserRepository.java
+++ b/backend/src/main/java/com/madeg/logistics/repository/UserRepository.java
@@ -2,11 +2,12 @@ package com.madeg.logistics.repository;
 
 import com.madeg.logistics.entity.User;
 import java.util.List;
-import org.springframework.data.repository.CrudRepository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UserRepository extends CrudRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long> {
   User findByUsername(String username);
 
   long countByRole(String role);

--- a/backend/src/main/java/com/madeg/logistics/service/CategoryService.java
+++ b/backend/src/main/java/com/madeg/logistics/service/CategoryService.java
@@ -32,8 +32,8 @@ public class CategoryService extends CommonService {
 
     if (categoryInput.getParentCategoryCode() != null && parentCategory == null) {
       throw new ResponseStatusException(
-          ResponseCode.NOTFOUND.getStatus(),
-          ResponseCode.NOTFOUND.getMessage("부모 카테고리"));
+          ResponseCode.NOT_FOUND.getStatus(),
+          ResponseCode.NOT_FOUND.getMessage("부모 카테고리"));
     }
 
     Category category = Category
@@ -61,8 +61,8 @@ public class CategoryService extends CommonService {
     if (patchInput.getParentCategoryCode() != null &&
         patchInput.getParentCategoryCode().equals(categoryCode)) {
       throw new ResponseStatusException(
-          ResponseCode.BADREQUEST.getStatus(),
-          ResponseCode.BADREQUEST.getMessage("부모 카테고리 코드는 카테고리 코드와 달라야 합니다"));
+          ResponseCode.BAD_REQUEST.getStatus(),
+          ResponseCode.BAD_REQUEST.getMessage("부모 카테고리 코드는 카테고리 코드와 달라야 합니다"));
     }
 
     Category parentCategory = null;
@@ -71,8 +71,8 @@ public class CategoryService extends CommonService {
           patchInput.getParentCategoryCode());
       if (parentCategory == null) {
         throw new ResponseStatusException(
-            ResponseCode.NOTFOUND.getStatus(),
-            ResponseCode.NOTFOUND.getMessage("부모 카테고리"));
+            ResponseCode.NOT_FOUND.getStatus(),
+            ResponseCode.NOT_FOUND.getMessage("부모 카테고리"));
       }
     }
     Category updatedCategory = new Category();

--- a/backend/src/main/java/com/madeg/logistics/service/CommonService.java
+++ b/backend/src/main/java/com/madeg/logistics/service/CommonService.java
@@ -88,8 +88,8 @@ public class CommonService {
 
   private void throwNotFound(String entityType) {
     throw new ResponseStatusException(
-        ResponseCode.NOTFOUND.getStatus(),
-        ResponseCode.NOTFOUND.getMessage(entityType));
+        ResponseCode.NOT_FOUND.getStatus(),
+        ResponseCode.NOT_FOUND.getMessage(entityType));
   }
 
   protected byte[] getImageBytes(MultipartFile image) {
@@ -100,8 +100,8 @@ public class CommonService {
       return image.getBytes();
     } catch (IOException e) {
       throw new ResponseStatusException(
-          ResponseCode.BADREQUEST.getStatus(),
-          ResponseCode.BADREQUEST.getMessage("잘못된 이미지 입력입니다"));
+          ResponseCode.BAD_REQUEST.getStatus(),
+          ResponseCode.BAD_REQUEST.getMessage("잘못된 이미지 입력입니다"));
     }
   }
 
@@ -114,8 +114,8 @@ public class CommonService {
       Integer stock2,
       String errorMsg) {
     if (stock1 < stock2) {
-      throw new ResponseStatusException(ResponseCode.BADREQUEST.getStatus(),
-          ResponseCode.BADREQUEST.getMessage(errorMsg));
+      throw new ResponseStatusException(ResponseCode.BAD_REQUEST.getStatus(),
+          ResponseCode.BAD_REQUEST.getMessage(errorMsg));
     }
   }
 

--- a/backend/src/main/java/com/madeg/logistics/service/ProductService.java
+++ b/backend/src/main/java/com/madeg/logistics/service/ProductService.java
@@ -1,8 +1,10 @@
 package com.madeg.logistics.service;
 
 import com.madeg.logistics.domain.ProductInput;
+import com.madeg.logistics.domain.ProductListReq;
 import com.madeg.logistics.domain.ProductPatch;
 import com.madeg.logistics.domain.ProductRes;
+import com.madeg.logistics.domain.ProductSpecification;
 import com.madeg.logistics.domain.SimplePageInfo;
 import com.madeg.logistics.entity.Category;
 import com.madeg.logistics.entity.Product;
@@ -14,6 +16,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -61,10 +64,9 @@ public class ProductService extends CommonService {
     productRepository.save(product);
   }
 
-  public ProductRes getProducts(ProductType type, Pageable pageable) {
-    Page<Product> page = type == null
-        ? productRepository.findAll(pageable)
-        : productRepository.findByType(type, pageable);
+  public ProductRes getProducts(ProductType type, ProductListReq productListReq, Pageable pageable) {
+    Specification<Product> spec = ProductSpecification.withDynamicQuery(type, productListReq);
+    Page<Product> page = productRepository.findAll(spec, pageable);
     List<Product> content = page.getContent();
 
     SimplePageInfo simplePageInfo = createSimplePageInfo(page);

--- a/backend/src/main/java/com/madeg/logistics/service/ProductService.java
+++ b/backend/src/main/java/com/madeg/logistics/service/ProductService.java
@@ -43,8 +43,8 @@ public class ProductService extends CommonService {
 
     if (existCategory == null) {
       throw new ResponseStatusException(
-          ResponseCode.NOTFOUND.getStatus(),
-          ResponseCode.NOTFOUND.getMessage("카테고리"));
+          ResponseCode.NOT_FOUND.getStatus(),
+          ResponseCode.NOT_FOUND.getMessage("카테고리"));
     }
 
     byte[] imageBytes = getImageBytes(productInput.getImg());
@@ -105,8 +105,8 @@ public class ProductService extends CommonService {
             patchInput.getCategoryCode());
         if (category == null) {
           throw new ResponseStatusException(
-              ResponseCode.NOTFOUND.getStatus(),
-              ResponseCode.NOTFOUND.getMessage("카테고리"));
+              ResponseCode.NOT_FOUND.getStatus(),
+              ResponseCode.NOT_FOUND.getMessage("카테고리"));
         }
         previousProduct.updateCategory(category);
       }

--- a/backend/src/main/java/com/madeg/logistics/service/SalesHistoryService.java
+++ b/backend/src/main/java/com/madeg/logistics/service/SalesHistoryService.java
@@ -98,8 +98,8 @@ public class SalesHistoryService extends CommonService {
 
     if (storeProduct == null) {
       throw new ResponseStatusException(
-          ResponseCode.NOTFOUND.getStatus(),
-          ResponseCode.NOTFOUND.getMessage("매장 제품"));
+          ResponseCode.NOT_FOUND.getStatus(),
+          ResponseCode.NOT_FOUND.getMessage("매장 제품"));
     }
 
     Page<SalesHistory> page = salesHistoryRepository.findByStoreProductAndSalesMonth(

--- a/backend/src/main/java/com/madeg/logistics/service/StoreService.java
+++ b/backend/src/main/java/com/madeg/logistics/service/StoreService.java
@@ -83,8 +83,8 @@ public class StoreService extends CommonService {
       store.updateType(StoreType.FIX);
     } else {
       throw new ResponseStatusException(
-          ResponseCode.BADREQUEST.getStatus(),
-          ResponseCode.BADREQUEST.getMessage("수수료과 매대비(고정비) 중 적어도 하나는 0보다 커야 합니다"));
+          ResponseCode.BAD_REQUEST.getStatus(),
+          ResponseCode.BAD_REQUEST.getMessage("수수료과 매대비(고정비) 중 적어도 하나는 0보다 커야 합니다"));
     }
   }
 

--- a/backend/src/main/java/com/madeg/logistics/service/UserService.java
+++ b/backend/src/main/java/com/madeg/logistics/service/UserService.java
@@ -33,7 +33,7 @@ public class UserService {
     User user = userRepository.findByUsername(loginInfo.getUserName());
 
     if (user == null) {
-      throw new ResponseStatusException(ResponseCode.NOTFOUND.getStatus(), ResponseCode.NOTFOUND.getMessage("사용자"));
+      throw new ResponseStatusException(ResponseCode.NOT_FOUND.getStatus(), ResponseCode.NOT_FOUND.getMessage("사용자"));
     }
 
     if (passwordEncoder.matches(loginInfo.getPassword(), user.getPassword())) {
@@ -49,8 +49,8 @@ public class UserService {
     }
 
     throw new ResponseStatusException(
-        ResponseCode.BADREQUEST.getStatus(),
-        ResponseCode.BADREQUEST.getMessage("유효하지 않은 비밀번호입니다"));
+        ResponseCode.BAD_REQUEST.getStatus(),
+        ResponseCode.BAD_REQUEST.getMessage("유효하지 않은 비밀번호입니다"));
   }
 
   public UserRefreshRes refreshAccessToken(String refreshToken) {
@@ -92,8 +92,8 @@ public class UserService {
   public void patchUser(Long id, UserPatch patchInput) {
     User previousUser = userRepository
         .findById(id)
-        .orElseThrow(() -> new ResponseStatusException(ResponseCode.NOTFOUND.getStatus(),
-            ResponseCode.NOTFOUND.getMessage("사용자")));
+        .orElseThrow(() -> new ResponseStatusException(ResponseCode.NOT_FOUND.getStatus(),
+            ResponseCode.NOT_FOUND.getMessage("사용자")));
 
     if (patchInput.getPassword() != null) {
       previousUser.setPassword(
@@ -105,8 +105,8 @@ public class UserService {
           patchInput.getRole() == Role.USER &&
           userRepository.countByRole(Role.ADMIN.name()) == 1) {
         throw new ResponseStatusException(
-            ResponseCode.BADREQUEST.getStatus(),
-            ResponseCode.BADREQUEST.getMessage("유일한 관리자 권한의 사용자의 권한을 바꿀 수 없습니다"));
+            ResponseCode.BAD_REQUEST.getStatus(),
+            ResponseCode.BAD_REQUEST.getMessage("유일한 관리자 권한의 사용자의 권한을 바꿀 수 없습니다"));
       }
       previousUser.setRole(patchInput.getRole());
     }
@@ -117,14 +117,14 @@ public class UserService {
   public void deleteUser(Long id) {
     User previousUser = userRepository
         .findById(id)
-        .orElseThrow(() -> new ResponseStatusException(ResponseCode.NOTFOUND.getStatus(),
-            ResponseCode.NOTFOUND.getMessage("사용자")));
+        .orElseThrow(() -> new ResponseStatusException(ResponseCode.NOT_FOUND.getStatus(),
+            ResponseCode.NOT_FOUND.getMessage("사용자")));
 
     if (previousUser.getRole().equals(Role.ADMIN) &&
         userRepository.countByRole(Role.ADMIN.name()) == 1) {
       throw new ResponseStatusException(
-          ResponseCode.BADREQUEST.getStatus(),
-          ResponseCode.BADREQUEST.getMessage("유일한 관리자 권한의 사용자를 삭제할 수 없습니다"));
+          ResponseCode.BAD_REQUEST.getStatus(),
+          ResponseCode.BAD_REQUEST.getMessage("유일한 관리자 권한의 사용자를 삭제할 수 없습니다"));
     }
 
     userRepository.delete(previousUser);


### PR DESCRIPTION
Hi @JoshRyu 
As you requested in [issue](https://github.com/JoshRyu/logistics/issues/35), I add the product filtering to the product retrieve API

- request By type PRODUCT and searchType product_name
![image](https://github.com/JoshRyu/logistics/assets/142554606/e8621ce4-14c6-41ef-827f-9833f40a92c9)

- request All 
![image](https://github.com/JoshRyu/logistics/assets/142554606/fd0ab239-d838-4ba9-b2fb-a28c7599ee53)


- I also change the all CRUDrepository to JPArepository to use `Specification` when filtering by searchkeywords

Please check this and I would really appreciate your feedback
