### PR TITLE
Add compareType to product retrieve api for various serach policy

### DIFF
--- a/backend/src/main/java/com/madeg/logistics/controller/ProductController.java
+++ b/backend/src/main/java/com/madeg/logistics/controller/ProductController.java
@@ -6,6 +6,7 @@ import com.madeg.logistics.domain.ProductListReq;
 import com.madeg.logistics.domain.ProductPatch;
 import com.madeg.logistics.domain.ProductRes;
 import com.madeg.logistics.entity.Product;
+import com.madeg.logistics.enums.CompareType;
 import com.madeg.logistics.enums.ProductSearchType;
 import com.madeg.logistics.enums.ProductType;
 import com.madeg.logistics.enums.ResponseCode;
@@ -19,6 +20,7 @@ import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -67,6 +69,7 @@ public class ProductController {
   public ResponseEntity<ProductRes> getProductList(
       @RequestParam(required = false) ProductType type,
       @RequestParam(required = false) ProductSearchType searchType,
+      @RequestParam(required = false) CompareType compareType,
       @RequestParam(required = false) String searchKeyWord,
       @PageableDefault(size = 10, page = 0, sort = "productCode", direction = Sort.Direction.ASC) Pageable pageable) {
     ProductRes products;
@@ -75,6 +78,7 @@ public class ProductController {
       ProductListReq productListReq = new ProductListReq();
       productListReq.setSearchKeyWord(searchKeyWord);
       productListReq.setSearchType(searchType);
+      productListReq.setCompareType(Optional.ofNullable(compareType).orElse(CompareType.E));
 
       products = productService.getProducts(type, productListReq, pageable);
     } catch (Exception e) {

--- a/backend/src/main/java/com/madeg/logistics/domain/ProductListReq.java
+++ b/backend/src/main/java/com/madeg/logistics/domain/ProductListReq.java
@@ -1,5 +1,6 @@
 package com.madeg.logistics.domain;
 
+import com.madeg.logistics.enums.CompareType;
 import com.madeg.logistics.enums.ProductSearchType;
 
 import lombok.Getter;
@@ -14,5 +15,7 @@ public class ProductListReq {
     private String searchKeyWord;
 
     private ProductSearchType searchType;
+
+    private CompareType compareType;
 
 }

--- a/backend/src/main/java/com/madeg/logistics/domain/ProductSpecification.java
+++ b/backend/src/main/java/com/madeg/logistics/domain/ProductSpecification.java
@@ -1,11 +1,13 @@
 package com.madeg.logistics.domain;
 
 import org.springframework.data.jpa.domain.Specification;
-
 import com.madeg.logistics.entity.Product;
+import com.madeg.logistics.enums.CompareType;
 import com.madeg.logistics.enums.ProductType;
 
+import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -32,12 +34,12 @@ public class ProductSpecification {
                                 "%" + productListReq.getSearchKeyWord() + "%"));
                         break;
                     case STOCK:
-                        predicates.add(
-                                builder.equal(root.get("stock"), Integer.parseInt(productListReq.getSearchKeyWord())));
+                        addComparablePredicate(predicates, builder, root, "stock",
+                                Integer.parseInt(productListReq.getSearchKeyWord()), productListReq.getCompareType());
                         break;
                     case PRICE:
-                        predicates.add(
-                                builder.equal(root.get("price"), new BigDecimal(productListReq.getSearchKeyWord())));
+                        addComparablePredicate(predicates, builder, root, "price",
+                                new BigDecimal(productListReq.getSearchKeyWord()), productListReq.getCompareType());
                         break;
                     case DESCRIPTION:
                         predicates.add(
@@ -48,5 +50,26 @@ public class ProductSpecification {
 
             return builder.and(predicates.toArray(new Predicate[0]));
         };
+    }
+
+    private static <T extends Comparable<T>> void addComparablePredicate(List<Predicate> predicates,
+            CriteriaBuilder builder, Root<Product> root, String fieldName, T value, CompareType compareType) {
+        switch (compareType) {
+            case E:
+                predicates.add(builder.equal(root.get(fieldName), value));
+                break;
+            case MT:
+                predicates.add(builder.greaterThan(root.get(fieldName), value));
+                break;
+            case LT:
+                predicates.add(builder.lessThan(root.get(fieldName), value));
+                break;
+            case MET:
+                predicates.add(builder.greaterThanOrEqualTo(root.get(fieldName), value));
+                break;
+            case LET:
+                predicates.add(builder.lessThanOrEqualTo(root.get(fieldName), value));
+                break;
+        }
     }
 }

--- a/backend/src/main/java/com/madeg/logistics/enums/CompareType.java
+++ b/backend/src/main/java/com/madeg/logistics/enums/CompareType.java
@@ -1,0 +1,9 @@
+package com.madeg.logistics.enums;
+
+public enum CompareType {
+    E,
+    MT,
+    LT,
+    MET,
+    LET
+}

--- a/backend/src/main/java/com/madeg/logistics/repository/ProductRepository.java
+++ b/backend/src/main/java/com/madeg/logistics/repository/ProductRepository.java
@@ -1,7 +1,6 @@
 package com.madeg.logistics.repository;
 
 import com.madeg.logistics.entity.Product;
-import com.madeg.logistics.enums.ProductType;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,8 +13,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ProductRepository extends JpaRepository<Product, String>, JpaSpecificationExecutor<Product> {
   Page<Product> findAll(Specification<Product> spec, Pageable pageable);
-
-  Page<Product> findByType(ProductType type, Pageable pageable);
 
   Product findByName(String name);
 


### PR DESCRIPTION
Hi @JoshRyu ~!

I have added the compareType field when we retrieving the products
i fixed the specification to solve the [issue](https://github.com/JoshRyu/logistics/issues/38)

- E is for Equal and MET is for More than or equals to, ...
<img width="738" alt="image" src="https://github.com/JoshRyu/logistics/assets/142554606/eb1bfd19-e3ac-4189-95e6-eff99d7107ba">

Please check when you have time!!